### PR TITLE
access_management for user

### DIFF
--- a/manifests/server/user.pp
+++ b/manifests/server/user.pp
@@ -37,6 +37,7 @@
 #
 define clickhouse::server::user(
   Optional[String] $password                          = undef,
+  Optional[Integer] $access_management                = undef,
   String $quota                                       = 'default',
   String $profile                                     = 'default',
   Optional[Array[String]] $allow_databases            = undef,
@@ -62,12 +63,13 @@ define clickhouse::server::user(
     group   => $user_file_group,
     mode    => '0664',
     content => epp("${module_name}/user.xml.epp", {
-      'user'            => $title,
-      'password'        => $real_password,
-      'quota'           => $quota,
-      'profile'         => $profile,
-      'allow_databases' => $allow_databases,
-      'networks'        => $networks,
+      'user'              => $title,
+      'password'          => $real_password,
+      'access_management' => $access_management,
+      'quota'             => $quota,
+      'profile'           => $profile,
+      'allow_databases'   => $allow_databases,
+      'networks'          => $networks,
     }),
   }
 

--- a/templates/user.xml.epp
+++ b/templates/user.xml.epp
@@ -4,6 +4,9 @@
 <% if $password { -%>
       <password_sha256_hex><%= $password %></password_sha256_hex>
 <% } -%>
+<% if $access_management { -%>
+      <access_management><%=$access_management%></access_management>
+<% } -%>
 <% if $quota { -%>
       <quota><%= $quota %></quota>
 <% } -%>

--- a/types/clickhouse_users.pp
+++ b/types/clickhouse_users.pp
@@ -1,11 +1,12 @@
 # lint:ignore:2sp_soft_tabs
-type Clickhouse::Clickhouse_users = Hash[String, Struct[{Optional[password]        => String,
-                                                         Optional[quota]           => String,
-                                                         Optional[profile]         => String,
-                                                         Optional[allow_databases] => Array[String],
-                                                         Optional[networks]        => Clickhouse::Clickhouse_networks,
-                                                         Optional[users_dir]       => Stdlib::Unixpath,
-                                                         Optional[user_file_owner] => String,
-                                                         Optional[user_file_group] => String,
-                                                         Optional[ensure]          => String}],1]
+type Clickhouse::Clickhouse_users = Hash[String, Struct[{Optional[password]          => String,
+                                                         Optional[quota]             => String,
+                                                         Optional[profile]           => String,
+                                                         Optional[access_management] => Integer,
+                                                         Optional[allow_databases]   => Array[String],
+                                                         Optional[networks]          => Clickhouse::Clickhouse_networks,
+                                                         Optional[users_dir]         => Stdlib::Unixpath,
+                                                         Optional[user_file_owner]   => String,
+                                                         Optional[user_file_group]   => String,
+                                                         Optional[ensure]            => String}],1]
 # lint:endignore


### PR DESCRIPTION
https://github.com/ClickHouse/ClickHouse/pull/10387

https://github.com/ClickHouse/ClickHouse/blob/master/docs/en/whats-new/changelog/2020.md#clickhouse-release-v20527-stable-2020-07-02

Added system tables for users, roles, grants, settings profiles, quotas, row policies; added commands SHOW USER, SHOW [CURRENT|ENABLED] ROLES, SHOW SETTINGS PROFILES. #10387 (Vitaly Baranov).